### PR TITLE
chore: release `0.2.0b11.dev1`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,10 +1,10 @@
 {% set name = "pyrovelocity" %}
-{% set version = "0.2.0b11.dev0" %}
+{% set version = "0.2.0b11.dev1" %}
 
 {% set gitorg = "pinellolab" %}
 # {% set gittag = "v0.2.0-beta.10" %}
 # {% set gitref = "beta" %}
-{% set gitrev = "2734fbea67519cf6632a7d40cc230b8c4f86b1ba" %}
+{% set gitrev = "dac426b7e1e73511e03aef7dfe68088479a70c58" %}
 
 package:
   name: {{ name|lower }}
@@ -19,7 +19,7 @@ source:
   # url: https://github.com/{{ gitorg }}/{{ name }}/archive/refs/tags/{{ gittag }}.tar.gz
   # url: https://github.com/{{ gitorg }}/{{ name }}/archive/refs/heads/{{ gitref }}.tar.gz
   url: https://github.com/{{ gitorg }}/{{ name }}/archive/{{ gitrev }}.tar.gz
-  sha256: 8e104b2a84a30ea964c35aa303112826f967aadda9840fd003da0d0025318248
+  sha256: 1be61bd443155e7d3861970653dceb96cf5378624a5e2dcb5bf40cd7b273ca9d
 
 build:
   entry_points:


### PR DESCRIPTION
- note dac426b7e1e73511e03aef7dfe68088479a70c58 has version set to `0.2.0b11.dev0`

this results in inconsistent versions listed by mamba/conda vs pip

<details><summary>mamba/pip version listing</summary>
<p>

```bash
mamba install conda-forge/label/pyrovelocity_dev::pyrovelocity=0.2.0b11.dev1=pyhff70e4c_0

mamba list | grep pyro
echo ""
pip list | grep pyro

numpyro                   0.14.0             pyhd8ed1ab_0    conda-forge
pyro-api                  0.1.2              pyhd8ed1ab_0    conda-forge
pyro-ppl                  1.9.0              pyhd8ed1ab_0    conda-forge
pyrovelocity              0.2.0b11.dev1      pyhff70e4c_0    conda-forge/label/pyrovelocity_dev

numpyro                   0.14.0
pyro-api                  0.1.2
pyro-ppl                  1.9.0+f02dfb9
pyrovelocity              0.2.0b11.dev0
```

```python
import pyrovelocity
print(pyrovelocity.__file__)
print(pyrovelocity.__version__)

/usr/local/lib/python3.10/site-packages/pyrovelocity/__init__.py
0.2.0b11.dev0

import pyro
print(pyro.__file__)
print(pyro.__version__)

/usr/local/lib/python3.10/site-packages/pyro/__init__.py
1.9.0+f02dfb9
```

</p>
</details> 